### PR TITLE
Refactor gen_bw and add gen_bw_sum, gen_bw_equalities and gen_bw_uf

### DIFF
--- a/src/bv2int.cpp
+++ b/src/bv2int.cpp
@@ -307,9 +307,8 @@ Term BV2Int::handle_bw_op(const Term & t,
   Term res;
   if (lazy_bw_) {
     // in lazy mode, don't want to add anything to extra_assertions_
-    // pass a throwaway vector instead
-    TermVec dummy_vec;
-    res = utils_.gen_bw(op, bv_width, granularity_, x, y, dummy_vec);
+    // just get the uf representation
+    res = utils_.gen_bw_uf(op, bv_width, x, y);
   } else {
     res = utils_.gen_bw(op, bv_width, granularity_, x, y, extra_assertions_);
   }

--- a/src/bv2int.cpp
+++ b/src/bv2int.cpp
@@ -287,8 +287,8 @@ bool BV2Int::is_bw_op(Op op)
 }
 
 Term BV2Int::get_explicit_bw(Op op,
-                                     uint64_t bv_width,
-                                     const TermVec & cached_children)
+                             uint64_t bv_width,
+                             const TermVec & cached_children)
 {
   return utils_.gen_bw(op, bv_width, granularity_, cached_children[0], cached_children[1], extra_assertions_);
 }
@@ -296,8 +296,8 @@ Term BV2Int::get_explicit_bw(Op op,
 
 
 Term BV2Int::handle_bw_op(const Term & t,
-                               uint64_t bv_width,
-                               const TermVec & cached_children)
+                          uint64_t bv_width,
+                          const TermVec & cached_children)
 {
   Op op = t->get_op();
   assert(cached_children.size() == 2);
@@ -312,29 +312,9 @@ Term BV2Int::handle_bw_op(const Term & t,
     y = tmp;
   }
 
-  Term res;
-  if (op.prim_op == BVAnd) {
-    TermVec args = { fbv_and(), bv_width_term, x, y };
-    res = solver_->make_term(Apply, args);
-  } else if (op.prim_op == BVOr) {
-    TermVec args = { fbv_or(), bv_width_term, x, y };
-    res = solver_->make_term(Apply, args);
-  } else if (op.prim_op == BVXor) {
-    TermVec args = { fbv_xor(), bv_width_term, x, y };
-    res = solver_->make_term(Apply, args);
-  } else {
-    assert(false);
-  }
-
+  Term res = get_explicit_bw(op, bv_width, TermVec({x, y}));
   fterms_.push_back(res);
 
-  if (!lazy_bw_) {
-    //eagerly add equations defining the term
-    Term uf_app = res;
-    Term explicit_sum = get_explicit_bw(op, bv_width, TermVec({x,y}));
-    Term eq = solver_->make_term(Equal, uf_app, explicit_sum);
-    extra_assertions_.push_back(eq);
-  }
   return res;
 }
 

--- a/src/bv2int.cpp
+++ b/src/bv2int.cpp
@@ -286,14 +286,6 @@ bool BV2Int::is_bw_op(Op op)
   return (op == BVAnd || op == BVOr || op == BVXor);
 }
 
-Term BV2Int::get_explicit_bw(Op op,
-                             uint64_t bv_width,
-                             const TermVec & cached_children)
-{
-  return utils_.gen_bw(op, bv_width, granularity_, cached_children[0], cached_children[1], extra_assertions_);
-}
-
-
 
 Term BV2Int::handle_bw_op(const Term & t,
                           uint64_t bv_width,
@@ -312,7 +304,16 @@ Term BV2Int::handle_bw_op(const Term & t,
     y = tmp;
   }
 
-  Term res = get_explicit_bw(op, bv_width, TermVec({x, y}));
+  Term res;
+  if (lazy_bw_) {
+    // in lazy mode, don't want to add anything to extra_assertions_
+    // pass a throwaway vector instead
+    TermVec dummy_vec;
+    res = utils_.gen_bw(op, bv_width, granularity_, x, y, dummy_vec);
+  } else {
+    res = utils_.gen_bw(op, bv_width, granularity_, x, y, extra_assertions_);
+  }
+
   fterms_.push_back(res);
 
   return res;

--- a/src/bv2int.h
+++ b/src/bv2int.h
@@ -39,10 +39,6 @@ class BV2Int : smt::IdentityWalker
   const smt::UnorderedTermSet & get_int_vars() const { return int_vars_; }
 
 
-  smt::Term get_explicit_bw(smt::Op op,
-                                    uint64_t bv_width,
-                                    const smt::TermVec & cached_children);
-
   uint64_t granularity() {return granularity_;}
   utils& get_utils() {return utils_;}
 

--- a/src/lbv2isolver.cpp
+++ b/src/lbv2isolver.cpp
@@ -456,8 +456,12 @@ bool LBV2ISolver::refine_final(Op op, const TermVec &fterms, TermVec &outlemmas)
     get_fbv_args(f, bv_width, a, b);
 
     if (opts.lazy_granularity == 0) {
-      Term full_def = utils.gen_bw(
-          op, bv_width, bv2int_->granularity(), a, b, side_effects);
+      Term full_def = utils.gen_bw_sum(op,
+                                       bv_width,
+                                       bv2int_->granularity(),
+                                       a,
+                                       b,
+                                       side_effects);
       Term l = solver_->make_term(Equal, f, full_def);
       Term se = solver_->make_term(true);
       for (auto t : side_effects) {
@@ -494,12 +498,12 @@ bool LBV2ISolver::refine_final(Op op, const TermVec &fterms, TermVec &outlemmas)
         Term b_least_block = utils.gen_intdiv(b, utils.pow2(j), side_effects);
         b_least_block =
             utils.gen_mod(b_least_block, utils.pow2(i - j + 1), side_effects);
-        Term lower_bound = utils.gen_bw(op,
-                                        k,
-                                        bv2int_->granularity(),
-                                        a_least_block,
-                                        b_least_block,
-                                        side_effects);
+        Term lower_bound = utils.gen_bw_sum(op,
+                                            k,
+                                            bv2int_->granularity(),
+                                            a_least_block,
+                                            b_least_block,
+                                            side_effects);
         Term lower_lemma = solver_->make_term(Le, lower_bound, f);
         for (Term & t : side_effects) {
           lower_lemma = solver_->make_term(And, lower_lemma, t);
@@ -519,12 +523,12 @@ bool LBV2ISolver::refine_final(Op op, const TermVec &fterms, TermVec &outlemmas)
         Term b_most_block = utils.gen_intdiv(b, utils.pow2(j), side_effects);
         b_most_block =
             utils.gen_mod(b_most_block, utils.pow2(i - j + 1), side_effects);
-        Term upper_bound = utils.gen_bw(op,
-                                        k,
-                                        bv2int_->granularity(),
-                                        a_most_block,
-                                        b_most_block,
-                                        side_effects);
+        Term upper_bound = utils.gen_bw_sum(op,
+                                            k,
+                                            bv2int_->granularity(),
+                                            a_most_block,
+                                            b_most_block,
+                                            side_effects);
         uint64_t slack_width = bv_width - k;
         Term two_to_the_slack_width = utils.pow2(slack_width);
         Term slack =

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -165,6 +165,23 @@ Term utils::gen_block(Op op,
   return gen_bitwise_int(op, block_size, left, right);
 }
 
+Term utils::gen_bw_uf(const Op op, uint64_t bv_width, const Term & a, const Term & b)
+{
+  Term bv_width_term = solver_->make_term(to_string(bv_width), int_sort_);
+  if (op.prim_op == BVAnd) {
+    TermVec args = { fbvand_, bv_width_term, a, b };
+    return solver_->make_term(Apply, args);
+  } else if (op.prim_op == BVOr) {
+    TermVec args = { fbvor_, bv_width_term, a, b };
+    return solver_->make_term(Apply, args);
+  } else if (op.prim_op == BVXor) {
+    TermVec args = { fbvxor_, bv_width_term, a, b };
+    return solver_->make_term(Apply, args);
+  } else {
+    assert(false);
+  }
+}
+
 Term utils::gen_bw_sum(const Op op, uint64_t bv_width, uint64_t granularity, const Term &a, const Term & b, TermVec& side_effects)
 {
   assert(granularity > 0);
@@ -239,20 +256,7 @@ Term utils::gen_bw(const Op op, const uint64_t bv_width, uint64_t granularity, c
 
 
   // sigma is the term, e.g., f_bvand(a,b)
-  Term sigma;
-  Term bv_width_term = solver_->make_term(to_string(bv_width), int_sort_);
-  if (op.prim_op == BVAnd) {
-    TermVec args = { fbvand_, bv_width_term, a, b };
-    sigma = solver_->make_term(Apply, args);
-  } else if (op.prim_op == BVOr) {
-    TermVec args = { fbvor_, bv_width_term, a, b };
-    sigma = solver_->make_term(Apply, args);
-  } else if (op.prim_op == BVXor) {
-    TermVec args = { fbvxor_, bv_width_term, a, b };
-    sigma = solver_->make_term(Apply, args);
-  } else {
-    assert(false);
-  }
+  Term sigma = gen_bw_uf(op, bv_width, a, b);
 
   uint64_t block_size = granularity;
   if (block_size > bv_width) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -165,8 +165,49 @@ Term utils::gen_block(Op op,
   return gen_bitwise_int(op, block_size, left, right);
 }
 
+Term utils::gen_bw_sum(const Op op, uint64_t bv_width, uint64_t granularity, const Term &a, const Term & b, TermVec& side_effects)
+{
+  assert(granularity > 0);
+
+  uint64_t block_size = granularity;
+  if (block_size > bv_width) {
+    block_size = bv_width;
+  }
+  while (bv_width % block_size != 0) {
+    block_size = block_size - 1;
+  }
+
+  uint64_t num_of_blocks = bv_width / block_size;
+  Term sum = int_zero_;
+  for (uint64_t i = 0; i < num_of_blocks; i++) {
+    Term block = gen_block(op, a, b, i, block_size, side_effects);
+    Term power_of_two = pow2(i);
+    Term sum_part = solver_->make_term(Mult, block, power_of_two);
+    sum = solver_->make_term(Plus, sum, sum_part);
+  }
+  return sum;
+}
+
 Term utils::gen_bw(const Op op, const uint64_t bv_width, uint64_t granularity, const Term &a, const Term &b, TermVec& side_effects) {
   assert(granularity > 0);
+
+
+  // sigma is the term, e.g., f_bvand(a,b)
+  Term sigma;
+  Term bv_width_term = solver_->make_term(to_string(bv_width), int_sort_);
+  if (op.prim_op == BVAnd) {
+    TermVec args = { fbvand_, bv_width_term, a, b };
+    sigma = solver_->make_term(Apply, args);
+  } else if (op.prim_op == BVOr) {
+    TermVec args = { fbvor_, bv_width_term, a, b };
+    sigma = solver_->make_term(Apply, args);
+  } else if (op.prim_op == BVXor) {
+    TermVec args = { fbvxor_, bv_width_term, a, b };
+    sigma = solver_->make_term(Apply, args);
+  } else {
+    assert(false);
+  }
+
   uint64_t block_size = granularity;
   if (block_size > bv_width) {
     block_size = bv_width;
@@ -176,14 +217,9 @@ Term utils::gen_bw(const Op op, const uint64_t bv_width, uint64_t granularity, c
   }
   uint64_t num_of_blocks = bv_width / block_size;
   if (opts.use_sum_bvops) {
-    Term sum = int_zero_;
-    for (uint64_t i = 0; i < num_of_blocks; i++) {
-      Term block = gen_block(op, a, b, i, block_size, side_effects);
-      Term power_of_two = pow2(i);
-      Term sum_part = solver_->make_term(Mult, block, power_of_two);
-      sum = solver_->make_term(Plus, sum, sum_part);
-    }
-    return sum;
+    Term sum = gen_bw_sum(op, bv_width, granularity, a, b, side_effects);
+    // add equality to extra assertions
+    side_effects.push_back(solver_->make_term(Equal, sigma, sum));
   } else {
     Sort intsort = solver_->make_sort(INT);
 
@@ -191,21 +227,6 @@ Term utils::gen_bw(const Op op, const uint64_t bv_width, uint64_t granularity, c
     // e.g. introduce bvand_x_y := (bvand x y)
     // and assert bvand_x_y[i] = min(x[i], y[i]) for each i up to width-1
     // using division and mod to extract bits
-    //sigma is the term, e.g., f_bvand(a,b)
-    Term sigma;
-    Term bv_width_term = solver_->make_term(to_string(bv_width), int_sort_);
-    if (op.prim_op == BVAnd) {
-      TermVec args = { fbvand_, bv_width_term, a, b };
-      sigma = solver_->make_term(Apply, args);
-    } else if (op.prim_op == BVOr) {
-      TermVec args = { fbvor_, bv_width_term, a, b };
-      sigma = solver_->make_term(Apply, args);
-    } else if (op.prim_op == BVXor) {
-      TermVec args = { fbvxor_, bv_width_term, a, b };
-      sigma = solver_->make_term(Apply, args);
-    } else {
-      assert(false);
-    }
     side_effects.push_back(make_range_constraint(sigma, bv_width));
 
     uint64_t i, j;
@@ -221,15 +242,16 @@ Term utils::gen_bw(const Op op, const uint64_t bv_width, uint64_t granularity, c
       sigma_ext = gen_intdiv(sigma, p, side_effects);
       p = pow2(i - j + 1);
       sigma_ext = gen_mod(sigma_ext, p, side_effects);
-      // now we assert that the two are equal
-      solver_->assert_formula(solver_->make_term(Equal, sigma_ext, block));
+      // add equality between blocks
+      side_effects.push_back(solver_->make_term(Equal, sigma_ext, block));
     }
-
-    // sigma is the new term for this bitwise operator
-    // and we've asserted that it is equivalent at each bit
-    // in the binary representation
-    return sigma;
   }
+
+  // sigma is the new term for this bitwise operator
+  // and depending on the setting we've either
+  // 1. asserted it's equal to the sum
+  // 2. asserted it's within the range constraints and each bit is equal
+  return sigma;
 }
 
 Term utils::gen_intdiv(const Term &a, const Term &b, TermVec& side_effects)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -188,6 +188,52 @@ Term utils::gen_bw_sum(const Op op, uint64_t bv_width, uint64_t granularity, con
   return sum;
 }
 
+void utils::gen_bw_equalities(const Op op,
+                              uint64_t bv_width,
+                              uint64_t granularity,
+                              const Term & a,
+                              const Term & b,
+                              const Term & sigma,
+                              TermVec & side_effects)
+{
+  assert(granularity > 0);
+
+  uint64_t block_size = granularity;
+  if (block_size > bv_width) {
+    block_size = bv_width;
+  }
+  while (bv_width % block_size != 0) {
+    block_size = block_size - 1;
+  }
+
+  uint64_t num_of_blocks = bv_width / block_size;
+
+  Sort intsort = solver_->make_sort(INT);
+
+  // add bitwise equality assertions over integers
+  // e.g. introduce bvand_x_y := (bvand x y)
+  // and assert bvand_x_y[i] = min(x[i], y[i]) for each i up to width-1
+  // using division and mod to extract bits
+  side_effects.push_back(make_range_constraint(sigma, bv_width));
+
+  uint64_t i, j;
+  Term block;
+  Term sigma_ext;
+  for (uint64_t n = 0; n < num_of_blocks; n++) {
+    block = gen_block(op, a, b, n, block_size, side_effects);
+    j = n * block_size;
+    i = j + block_size - 1;
+    // now extract the corresponding bits of sigma
+    // ((_ extract i j) a) is a / 2^j mod 2^{i-j+1}
+    Term p = pow2(j);
+    sigma_ext = gen_intdiv(sigma, p, side_effects);
+    p = pow2(i - j + 1);
+    sigma_ext = gen_mod(sigma_ext, p, side_effects);
+    // add equality between blocks
+    side_effects.push_back(solver_->make_term(Equal, sigma_ext, block));
+  }
+}
+
 Term utils::gen_bw(const Op op, const uint64_t bv_width, uint64_t granularity, const Term &a, const Term &b, TermVec& side_effects) {
   assert(granularity > 0);
 
@@ -221,30 +267,7 @@ Term utils::gen_bw(const Op op, const uint64_t bv_width, uint64_t granularity, c
     // add equality to extra assertions
     side_effects.push_back(solver_->make_term(Equal, sigma, sum));
   } else {
-    Sort intsort = solver_->make_sort(INT);
-
-    // add bitwise equality assertions over integers
-    // e.g. introduce bvand_x_y := (bvand x y)
-    // and assert bvand_x_y[i] = min(x[i], y[i]) for each i up to width-1
-    // using division and mod to extract bits
-    side_effects.push_back(make_range_constraint(sigma, bv_width));
-
-    uint64_t i, j;
-    Term block;
-    Term sigma_ext;
-    for (uint64_t n = 0; n < num_of_blocks; n++) {
-      block = gen_block(op, a, b, n, block_size, side_effects);
-      j = n * block_size;
-      i = j + block_size - 1;
-      // now extract the corresponding bits of sigma
-      // ((_ extract i j) a) is a / 2^j mod 2^{i-j+1}
-      Term p = pow2(j);
-      sigma_ext = gen_intdiv(sigma, p, side_effects);
-      p = pow2(i - j + 1);
-      sigma_ext = gen_mod(sigma_ext, p, side_effects);
-      // add equality between blocks
-      side_effects.push_back(solver_->make_term(Equal, sigma_ext, block));
-    }
+    gen_bw_equalities(op, bv_width, granularity, a, b, sigma, side_effects);
   }
 
   // sigma is the new term for this bitwise operator

--- a/src/utils.h
+++ b/src/utils.h
@@ -13,6 +13,13 @@ public:
   smt::Term gen_intdiv(const smt::Term &a, const smt::Term &b, smt::TermVec& side_effects);
   smt::Term gen_mod(const smt::Term &a, const smt::Term &b, smt::TermVec& side_effects);
   smt::Term gen_bw_sum(const smt::Op op, uint64_t bv_width, uint64_t granularity, const smt::Term &a, const smt::Term &b, smt::TermVec& side_effects);
+  void gen_bw_equalities(const smt::Op op,
+                         uint64_t bv_width,
+                         uint64_t granularity,
+                         const smt::Term & a,
+                         const smt::Term & b,
+                         const smt::Term & sigma,
+                         smt::TermVec & side_effects);
   smt::Term gen_bw(const smt::Op op, const uint64_t bv_width, uint64_t granularity, const smt::Term &a, const smt::Term &b, smt::TermVec& side_effects);
   static std::string pow2_str(uint64_t k);
   smt::Term make_range_constraint(const smt::Term & var, uint64_t bv_width);

--- a/src/utils.h
+++ b/src/utils.h
@@ -12,6 +12,10 @@ public:
   smt::Term pow2(uint64_t k);
   smt::Term gen_intdiv(const smt::Term &a, const smt::Term &b, smt::TermVec& side_effects);
   smt::Term gen_mod(const smt::Term &a, const smt::Term &b, smt::TermVec& side_effects);
+  smt::Term gen_bw_uf(const smt::Op op,
+                      uint64_t bv_width,
+                      const smt::Term & a,
+                      const smt::Term & b);
   smt::Term gen_bw_sum(const smt::Op op, uint64_t bv_width, uint64_t granularity, const smt::Term &a, const smt::Term &b, smt::TermVec& side_effects);
   void gen_bw_equalities(const smt::Op op,
                          uint64_t bv_width,

--- a/src/utils.h
+++ b/src/utils.h
@@ -12,6 +12,7 @@ public:
   smt::Term pow2(uint64_t k);
   smt::Term gen_intdiv(const smt::Term &a, const smt::Term &b, smt::TermVec& side_effects);
   smt::Term gen_mod(const smt::Term &a, const smt::Term &b, smt::TermVec& side_effects);
+  smt::Term gen_bw_sum(const smt::Op op, uint64_t bv_width, uint64_t granularity, const smt::Term &a, const smt::Term &b, smt::TermVec& side_effects);
   smt::Term gen_bw(const smt::Op op, const uint64_t bv_width, uint64_t granularity, const smt::Term &a, const smt::Term &b, smt::TermVec& side_effects);
   static std::string pow2_str(uint64_t k);
   smt::Term make_range_constraint(const smt::Term & var, uint64_t bv_width);


### PR DESCRIPTION
This PR would change `gen_bw` and add a new utils function `gen_bw_sum`. 

`gen_bw` would now always return the UF application for the bitwise op, and it will add any assertions to the side effects instead of asserting them directly. For the sum option, it adds the equality between the sum and the uf application to side effects

sometimes (like in refine_final for lazy mode) it only needs the sum. This would also add a new utils function `gen_bw_sum` that returns the sum instead of the UF application, and doesn't add any side effects (except the ones produced by gen_block)

This also adds helper functions for creating the bitwise equalities in `boolcomp-bvops` and a helper for generating the UF: `gen_bw_uf`

The motivation behind this refactor is to better support `use-boolcomp-bvops` in the lazy mode.