### PR TITLE
Update smt switch version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(GMP REQUIRED)
 add_library(lazybv2int "${LBV2I_LIB_TYPE}"
   "${PROJECT_SOURCE_DIR}/src/utils.cpp"
   "${PROJECT_SOURCE_DIR}/src/lbv2isolver.cpp"
+  "${PROJECT_SOURCE_DIR}/src/identity_walker.cpp"
   "${PROJECT_SOURCE_DIR}/src/bv2int.cpp"
   "${PROJECT_SOURCE_DIR}/src/preprocessor.cpp"
   "${PROJECT_SOURCE_DIR}/src/postprocessor.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,20 @@
 cmake_minimum_required(VERSION 3.1)
 
+
 project(lazybv2int)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
 include_directories("${PROJECT_SOURCE_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}/src")
 
 message("-- CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
+
+find_package(GMP REQUIRED)
 
 add_library(lazybv2int "${LBV2I_LIB_TYPE}"
   "${PROJECT_SOURCE_DIR}/src/utils.cpp"
@@ -51,19 +56,19 @@ target_include_directories(lazybv2int PUBLIC "${PROJECT_SOURCE_DIR}/contrib")
 target_include_directories(lazybv2int PUBLIC "${PROJECT_SOURCE_DIR}/contrib/smtlib2parser-1.4")
 #target_include_directories(lazybv2int PUBLIC "${PROJECT_SOURCE_DIR}/contrib/optionparser-1.7/src")
 target_include_directories(lazybv2int PUBLIC "${PROJECT_SOURCE_DIR}/deps/smt-switch/local/include")
+target_include_directories (lazybv2int PUBLIC "${GMP_INCLUDE_DIR}")
 
 # HACK: Using MathSAT parser (need to expose some of smt-switch internals)
 target_include_directories(lazybv2int PUBLIC
   "${PROJECT_SOURCE_DIR}/smt-switch/local/include"
-  "${PROJECT_SOURCE_DIR}/deps/smt-switch"
-  "${PROJECT_SOURCE_DIR}/deps/smt-switch/include"
   "${PROJECT_SOURCE_DIR}/deps/mathsat/include")
 
 
 target_link_libraries(lazybv2int PUBLIC "${PROJECT_SOURCE_DIR}/deps/smt-switch/local/lib/libsmt-switch-msat.a")
 target_link_libraries(lazybv2int PUBLIC "${PROJECT_SOURCE_DIR}/deps/smt-switch/local/lib/libsmt-switch-cvc4.a")
 target_link_libraries(lazybv2int PUBLIC "${PROJECT_SOURCE_DIR}/deps/smt-switch/local/lib/libsmt-switch.a")
-target_link_libraries(lazybv2int PUBLIC gmp)
+target_link_libraries(lazybv2int PUBLIC ${GMPXX_LIBRARIES})
+target_link_libraries(lazybv2int PUBLIC ${GMP_LIBRARIES})
 target_link_libraries(lazybv2int PUBLIC pthread)
 
 add_executable(lazybv2int-bin

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -1,0 +1,19 @@
+# Find GMP
+# GMP_FOUND - system has GMP lib
+# GMP_INCLUDE_DIR - the GMP include directory
+# GMP_LIBRARIES - Libraries needed to use GMP
+
+find_path(GMP_INCLUDE_DIR NAMES gmp.h gmpxx.h)
+find_library(GMP_LIBRARIES NAMES gmp)
+find_library(GMPXX_LIBRARIES NAMES gmpxx)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GMP DEFAULT_MSG GMP_INCLUDE_DIR GMP_LIBRARIES)
+
+mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARIES)
+if(GMP_LIBRARIES)
+  message(STATUS "Found GMP libs: ${GMP_LIBRARIES}")
+endif()
+if (GMPXX_LIBRARIES)
+  message(STATUS "Found GMPXX libs: ${GMPXX_LIBRARIES}")
+endif()

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -32,8 +32,8 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
     git clone https://github.com/makaimann/smt-switch
     cd smt-switch
-    git checkout -f 969a5c0850e639c5547f0e6166491c85bd2e1e4d
-    ./contrib/setup-cvc4.sh
+    git checkout -f 970f5aaa9f262f30f26f85f2de9364be33483d7b
+    ./travis-scripts/download-cvc4.sh
     ./configure.sh --cvc4 --msat --msat-home=../mathsat --prefix=local --static $CONF_OPTS
     cd build
     make -j$(nproc)

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -34,7 +34,9 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     cd smt-switch
     git checkout -f 970f5aaa9f262f30f26f85f2de9364be33483d7b
     ./travis-scripts/download-cvc4.sh
-    ./configure.sh --cvc4 --msat --msat-home=../mathsat --prefix=local --static $CONF_OPTS
+    ./contrib/setup-flex.sh
+    ./contrib/setup-bison.sh
+    ./configure.sh --cvc4 --msat --msat-home=../mathsat --prefix=local --static --smtlib-reader $CONF_OPTS
     cd build
     make -j$(nproc)
     make test

--- a/src/bv2int.cpp
+++ b/src/bv2int.cpp
@@ -13,7 +13,7 @@ namespace lbv2i {
 
 static bool is_simple_op(Op op)
 {
-  vector<Op> simple_op = { And,  Or,     Xor,      Not,    Implies, Iff,
+  vector<Op> simple_op = { And,  Or,     Xor,      Not,    Implies,
                            Ite,  Equal,  Distinct, Plus,   Minus,   Negate,
                            Mult, IntDiv, Lt,       Le,     Gt,      Ge,
                            Mod,  Abs,    Pow,      To_Real };

--- a/src/bv2int.h
+++ b/src/bv2int.h
@@ -1,22 +1,21 @@
 #pragma once
 
-#include "smt-switch/identity_walker.h"
+#include "identity_walker.h"
 #include "smt-switch/smt.h"
 #include "utils.h"
 
 namespace lbv2i {
 
-
-class BV2Int : smt::IdentityWalker
+class BV2Int : IdentityWalker
 {
  public:
   BV2Int(smt::SmtSolver & solver, bool clear_cache, bool lazy_bw = false);
   ~BV2Int();
 
-  typedef smt::IdentityWalker super;
+  typedef IdentityWalker super;
   // it will also use the walker infrastructure
 
-  smt::WalkerStepResult visit_term(smt::Term & term);
+  WalkerStepResult visit_term(smt::Term & term);
   smt::Term convert(smt::Term & t);
 
   void reset();

--- a/src/identity_walker.cpp
+++ b/src/identity_walker.cpp
@@ -1,0 +1,104 @@
+/*********************                                                        */
+/*! \file identity_walker.cpp
+** \verbatim
+** Top contributors (to current version):
+**   Makai Mann
+**
+** This is a copy of an old version of identity_walker.cpp from the smt-switch
+** project. This needed to be copied because cache_ was protected at the time
+** instead of private as in the latter versions of smt-switch.
+**
+** The original copyright header was as follows:
+** This file is part of the smt-switch project.
+** Copyright (c) 2020 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief Identity walker class that can be inherited and modified for
+**        term traversal and manipulation.
+**
+**/
+
+#include "identity_walker.h"
+
+using namespace smt;
+using namespace std;
+
+namespace lbv2i {
+
+Term IdentityWalker::visit(Term & term)
+{
+  if (clear_cache_) {
+    cache_.clear();
+  }
+
+  TermVec to_visit({ term });
+  // Note: visited is different than cache keys
+  //       might want to visit without saving to the cache
+  //       and if something is in the cache it wouldn't
+  //       visit it again (e.g. in post-order traversal)
+  UnorderedTermSet visited;
+
+  Term t;
+  WalkerStepResult res;
+  while (to_visit.size()) {
+    t = to_visit.back();
+    to_visit.pop_back();
+
+    if (cache_.find(t) != cache_.end()) {
+      // cache hit
+      continue;
+    }
+
+    // in preorder if it has not been seen before
+    preorder_ = (visited.find(t) == visited.end());
+    // add to visited after determining whether we're in the pre-
+    // or post-order
+    visited.insert(t);
+    res = visit_term(t);
+
+    if (res == Walker_Abort) {
+      if (cache_.find(term) != cache_.end()) {
+        return cache_.at(term);
+      }
+      return term;
+    }
+
+    if (preorder_) {
+      if (res == Walker_Continue) {
+        to_visit.push_back(t);
+        for (auto tt : t) {
+          to_visit.push_back(tt);
+        }
+      }
+    }
+  }
+
+  if (cache_.find(term) == cache_.end()) {
+    return term;
+  } else {
+    return cache_.at(term);
+  }
+}
+
+WalkerStepResult IdentityWalker::visit_term(Term & term)
+{
+  if (!preorder_) {
+    Op op = term->get_op();
+    if (!op.is_null()) {
+      TermVec cached_children;
+      for (auto t : term) {
+        cached_children.push_back(cache_.at(t));
+      }
+      cache_[term] = solver_->make_term(op, cached_children);
+    } else {
+      // just keep the leaves the same
+      cache_[term] = term;
+    }
+  }
+
+  return Walker_Continue;
+}
+
+}  // namespace lbv2i

--- a/src/identity_walker.h
+++ b/src/identity_walker.h
@@ -1,0 +1,82 @@
+/*********************                                                        */
+/*! \file identity_walker.h
+** \verbatim
+** Top contributors (to current version):
+**   Makai Mann
+**
+** This is a copy of an old version of identity_walker.h from the smt-switch
+** project. This needed to be copied because cache_ was protected at the time
+** instead of private as in the latter versions of smt-switch.
+**
+** The original copyright header was as follows:
+** This file is part of the smt-switch project.
+** Copyright (c) 2020 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief Identity walker class that can be inherited and modified for
+**        term traversal and manipulation.
+**
+**/
+
+#pragma once
+
+#include <utility>
+
+#include "smt-switch/smt.h"
+
+namespace lbv2i {
+/** \enum
+ * Walker_Continue : rebuild the current term and continue
+ * Walker_Skip     : skip this term and all subterms
+ * Walker_Abort    : abort visiting
+ */
+enum WalkerStepResult
+{
+  Walker_Continue = 0,
+  Walker_Skip,
+  Walker_Abort
+};
+
+/** \class
+ * IdentityWalker class.
+ * To implement your own walker, inherit this class and implement the
+ * visit_term method.
+ *
+ * If clear_cache is set, the cache is cleared between calls to visit
+ * otherwise, the cache persists
+ *
+ * Important Note: The term arguments should belong to the solver provided
+ * to the identity walker, otherwise the behavior is undefined.
+ */
+class IdentityWalker
+{
+ public:
+  IdentityWalker(smt::SmtSolver & solver, bool clear_cache)
+      : solver_(solver), clear_cache_(clear_cache){};
+
+  /** Visit a term and all its subterms in a pre- and post-order traversal
+   *  @param term the term to visit
+   *  @return the term after visiting (returns the value of cache[term]
+   *     -- if it has been cached and returns term otherwise)
+   */
+  smt::Term visit(smt::Term & term);
+
+ protected:
+  /** Visit a single term.
+   *  Implement this method in a derived class to change the behavior
+   *  of the walker
+   *  @param term the term to visit
+   *  @return a WalkerStepResult to tell the visit method how to proceed
+   */
+  virtual WalkerStepResult visit_term(smt::Term & term);
+
+  smt::SmtSolver & solver_;     /**< the solver to use for rebuilding terms */
+  smt::UnorderedTermMap cache_; /**< cache for updating terms */
+  bool clear_cache_; /**< if true, clears the cache between calls to visit */
+  bool preorder_; /**< true when the current term is being visited for the first
+                     time. For use in visit_term */
+};
+
+}  // namespace lbv2i

--- a/src/lbv2isolver.cpp
+++ b/src/lbv2isolver.cpp
@@ -66,25 +66,24 @@ static void get_fbv_args(const Term & f,
 
 
 LBV2ISolver::LBV2ISolver(SmtSolver & solver, bool lazy)
-    : bv2int_(new BV2Int(solver, false, lazy)),
-      prepro_(new Preprocessor(solver)),
-      postpro_(new Postprocessor(solver, &(bv2int_->get_utils()))),
-      axioms_(
-          solver, bv2int_->fbv_and()),
-      solver_(solver),
-      tr_s_checker_(s_checker_),
-      s_checker_(NULL),
-      lazy_(lazy),
-      AbsSmtSolver(opts.solver=="CVC4" ? CVC4 : MSAT)
+  : AbsSmtSolver(opts.solver=="CVC4" ? CVC4 : MSAT),
+    bv2int_(new BV2Int(solver, false, lazy)),
+    prepro_(new Preprocessor(solver)),
+    postpro_(new Postprocessor(solver, &(bv2int_->get_utils()))),
+    axioms_(
+            solver, bv2int_->fbv_and()),
+    solver_(solver),
+    // create MathSAT Solver without a shadow DAG (e.g. LoggingSolver wrapper)
+    s_checker_(MsatSolverFactory::create(false)),
+    tr_s_checker_(s_checker_),
+    lazy_(lazy)
 {
   last_asserted_size_ = 0;
   if (opts.print_values || opts.print_sigma_values || opts.lazy) {
     solver_->set_opt("produce-models", "true");
   }
 
-  // create MathSAT Solver without a shadow DAG (e.g. LoggingSolver wrapper)
-  s_checker_ = MsatSolverFactory::create(false);
-  s_checker_->set_opt("produce-unsat-cores", "true");
+  s_checker_->set_opt("produce-unsat-assumptions", "true");
   s_checker_base_assump_ = s_checker_->make_symbol("s_checker_base_assump",
                                                    s_checker_->make_sort(BOOL));
 }

--- a/src/lbv2isolver.cpp
+++ b/src/lbv2isolver.cpp
@@ -234,11 +234,6 @@ Term LBV2ISolver::make_term(const Op op,
   return solver_->make_term(op, t0, t1, t2);
 }
 
-Term LBV2ISolver::make_term(const string val, const Sort & sort, uint64_t base)
-{
-  return solver_->make_term(val, sort, base);
-}
-
 Term LBV2ISolver::make_symbol(const std::string name, const Sort & sort)
 {
   return solver_->make_symbol(name, sort);

--- a/src/lbv2isolver.cpp
+++ b/src/lbv2isolver.cpp
@@ -109,11 +109,9 @@ Result LBV2ISolver::check_sat_assuming(const TermVec & assumptions)
   return r;
 }
 
-TermVec LBV2ISolver::get_unsat_core()
+void LBV2ISolver::get_unsat_assumptions(UnorderedTermSet & core)
 {
-  assert(false);
-  TermVec core;
-  return core;
+  solver_->get_unsat_assumptions(core);
 }
 
 Term LBV2ISolver::substitute(const Term term,
@@ -247,6 +245,11 @@ Term LBV2ISolver::make_symbol(const std::string name, const Sort & sort)
   return solver_->make_symbol(name, sort);
 }
 
+Term LBV2ISolver::make_param(const string name, const Sort & sort)
+{
+  throw SmtException("LBV2ISolver does not support quantifiers");
+}
+
 Sort LBV2ISolver::make_sort(const std::string name, uint64_t arity) const
 {
   return solver_->make_sort(name, arity);
@@ -285,6 +288,11 @@ Sort LBV2ISolver::make_sort(const SortKind sk,
 Sort LBV2ISolver::make_sort(const SortKind sk, const SortVec & sorts) const
 {
   return solver_->make_sort(sk, sorts);
+}
+
+Sort LBV2ISolver::make_sort(const Sort & sort_con, const SortVec & sorts) const
+{
+  return solver_->make_sort(sort_con, sorts);
 }
 
 void LBV2ISolver::set_opt(string op, string value)

--- a/src/lbv2isolver.cpp
+++ b/src/lbv2isolver.cpp
@@ -1,19 +1,19 @@
 #include "lbv2isolver.h"
 
 #include <assert.h>
+
 #include <fstream>
 #include <iostream>
 #include <regex>
+#include <sstream>
 #include <streambuf>
 
-#include "msat/include/msat_term.h"
-
+#include "opts.h"
+#include "smt-switch/boolector_factory.h"
 #include "smt-switch/cvc4_factory.h"
 #include "smt-switch/msat_factory.h"
-#include "smt-switch/boolector_factory.h"
+#include "smt-switch/msat_term.h"
 #include "smt-switch/solver_enums.h"
-
-#include "opts.h"
 #include "smtlibmsatparser.h"
 
 using namespace smt;

--- a/src/lbv2isolver.cpp
+++ b/src/lbv2isolver.cpp
@@ -1080,8 +1080,8 @@ bool LBV2ISolver::try_sat_check(TermVec &outlemmas)
     Term lemma = solver_->make_term(false);
     if (bool_assump.size() > 0) {
       try {
-        TermVec core = s_checker_->get_unsat_core();
-        UnorderedTermSet core_set(core.begin(), core.end());
+        UnorderedTermSet core_set;
+        s_checker_->get_unsat_assumptions(core_set);
 
         assert(orig_assump.size() == bool_assump.size());
 

--- a/src/lbv2isolver.h
+++ b/src/lbv2isolver.h
@@ -34,7 +34,7 @@ class LBV2ISolver : public smt::AbsSmtSolver
   smt::Result check_sat();
   smt::Result check_sat_assuming(const smt::TermVec & assumptions);
 
-  smt::TermVec get_unsat_core();
+  void get_unsat_assumptions(smt::UnorderedTermSet & core) override;
 
   smt::Term substitute(const smt::Term term,
                        const smt::UnorderedTermMap & substitution_map) const;
@@ -51,8 +51,11 @@ class LBV2ISolver : public smt::AbsSmtSolver
                       const smt::Sort & sort2,
                       const smt::Sort & sort3) const;
   smt::Sort make_sort(const smt::SortKind sk, const smt::SortVec & sorts) const;
+  smt::Sort make_sort(const smt::Sort & sort_con,
+                      const smt::SortVec & sorts) const override;
 
   smt::Term make_symbol(const std::string name, const smt::Sort & sort);
+  smt::Term make_param(const std::string name, const smt::Sort & sort) override;
   smt::Term make_term(const smt::Op op, const smt::TermVec & terms) const;
   smt::Term make_term(const smt::Op op, const smt::Term & t) const;
   smt::Term make_term(const smt::Op op,

--- a/src/lbv2isolver.h
+++ b/src/lbv2isolver.h
@@ -19,88 +19,108 @@ class LBV2ISolver : public smt::AbsSmtSolver
 
   smt::Result solve();
 
-  void push(uint64_t num = 1);
-  void pop(uint64_t num = 1);
-  void reset();
-  void reset_assertions();
-  void set_logic(const std::string logic_name);
-  void set_opt(std::string op, std::string value);
-  void assert_formula(const smt::Term & f);
+  void push(uint64_t num = 1) override;
+  void pop(uint64_t num = 1) override;
+  void reset() override;
+  void reset_assertions() override;
+  void set_logic(const std::string logic_name) override;
+  void set_opt(std::string op, std::string value) override;
+  void assert_formula(const smt::Term & f) override;
   void do_assert_formula();
   void dump_smt2();
-  smt::Term get_value(const smt::Term & t) const;
-  smt::UnorderedTermMap get_array_values(const smt::Term & arr,
-                                         smt::Term & out_const_base) const;
-  smt::Result check_sat();
-  smt::Result check_sat_assuming(const smt::TermVec & assumptions);
+  smt::Term get_value(const smt::Term & t) const override;
+  smt::UnorderedTermMap get_array_values(
+      const smt::Term & arr, smt::Term & out_const_base) const override;
+  smt::Result check_sat() override;
+  smt::Result check_sat_assuming(const smt::TermVec & assumptions) override;
 
   void get_unsat_assumptions(smt::UnorderedTermSet & core) override;
 
-  smt::Term substitute(const smt::Term term,
-                       const smt::UnorderedTermMap & substitution_map) const;
+  smt::Term substitute(
+      const smt::Term term,
+      const smt::UnorderedTermMap & substitution_map) const override;
 
-  smt::Sort make_sort(const smt::SortKind sk) const;
-  smt::Sort make_sort(const std::string name, uint64_t arity) const;
-  smt::Sort make_sort(const smt::SortKind sk, uint64_t size) const;
-  smt::Sort make_sort(const smt::SortKind sk, const smt::Sort & sort1) const;
+  smt::Sort make_sort(const smt::SortKind sk) const override;
+  smt::Sort make_sort(const std::string name, uint64_t arity) const override;
+  smt::Sort make_sort(const smt::SortKind sk, uint64_t size) const override;
+  smt::Sort make_sort(const smt::SortKind sk,
+                      const smt::Sort & sort1) const override;
   smt::Sort make_sort(const smt::SortKind sk,
                       const smt::Sort & sort1,
-                      const smt::Sort & sort2) const;
+                      const smt::Sort & sort2) const override;
   smt::Sort make_sort(const smt::SortKind sk,
                       const smt::Sort & sort1,
                       const smt::Sort & sort2,
-                      const smt::Sort & sort3) const;
-  smt::Sort make_sort(const smt::SortKind sk, const smt::SortVec & sorts) const;
+                      const smt::Sort & sort3) const override;
+  smt::Sort make_sort(const smt::SortKind sk,
+                      const smt::SortVec & sorts) const override;
   smt::Sort make_sort(const smt::Sort & sort_con,
                       const smt::SortVec & sorts) const override;
 
-  smt::Term make_symbol(const std::string name, const smt::Sort & sort);
+  smt::Term make_symbol(const std::string name,
+                        const smt::Sort & sort) override;
   smt::Term make_param(const std::string name, const smt::Sort & sort) override;
-  smt::Term make_term(const smt::Op op, const smt::TermVec & terms) const;
-  smt::Term make_term(const smt::Op op, const smt::Term & t) const;
+  smt::Term make_term(const smt::Op op,
+                      const smt::TermVec & terms) const override;
+  smt::Term make_term(const smt::Op op, const smt::Term & t) const override;
   smt::Term make_term(const smt::Op op,
                       const smt::Term & t0,
-                      const smt::Term & t1) const;
+                      const smt::Term & t1) const override;
   smt::Term make_term(const smt::Op op,
                       const smt::Term & t0,
                       const smt::Term & t1,
-                      const smt::Term & t2) const;
+                      const smt::Term & t2) const override;
   smt::Term make_term(const std::string val,
                       const smt::Sort & sort,
-                      uint64_t base = 10);
+                      uint64_t base = 10) const override;
 
-  smt::Term make_term(bool b) const;
-  smt::Term make_term(int64_t i, const smt::Sort & sort) const;
-  smt::Term make_term(const smt::Term & val, const smt::Sort & sort) const;
-  smt::Term make_term(const std::string val,
-                      const smt::Sort & sort,
-                      uint64_t base = 10) const;
+  smt::Term make_term(bool b) const override;
+  smt::Term make_term(int64_t i, const smt::Sort & sort) const override;
+  smt::Term make_term(const smt::Term & val,
+                      const smt::Sort & sort) const override;
 
-  smt::Sort make_sort(const smt::DatatypeDecl & d) const {
+  smt::Sort make_sort(const smt::DatatypeDecl & d) const override
+  {
     throw NotImplementedException("Not Implemented");
   };
-  smt::DatatypeDecl make_datatype_decl(const std::string & s) {
+  smt::DatatypeDecl make_datatype_decl(const std::string & s) override
+  {
     throw NotImplementedException("Not Implemented");
   };
-  smt::DatatypeConstructorDecl make_datatype_constructor_decl(const std::string s) {
+  smt::DatatypeConstructorDecl make_datatype_constructor_decl(
+      const std::string s) override
+  {
     throw NotImplementedException("Not Implemented");
   };
-  void add_constructor(smt::DatatypeDecl & dt, const smt::DatatypeConstructorDecl & con) const {
+  void add_constructor(smt::DatatypeDecl & dt,
+                       const smt::DatatypeConstructorDecl & con) const override
+  {
     throw NotImplementedException("Not Implemented");
   };
-  void add_selector(smt::DatatypeConstructorDecl & dt, const std::string & name, const smt::Sort & s) const {
+  void add_selector(smt::DatatypeConstructorDecl & dt,
+                    const std::string & name,
+                    const smt::Sort & s) const override
+  {
     throw NotImplementedException("Not Implemented");
   };
-  void add_selector_self(smt::DatatypeConstructorDecl & dt, const std::string & name) const {
+  void add_selector_self(smt::DatatypeConstructorDecl & dt,
+                         const std::string & name) const override
+  {
     throw NotImplementedException("Not Implemented");
   };
-  smt::Term get_constructor(const smt::Sort & s, std::string name) const {
+  smt::Term get_constructor(const smt::Sort & s,
+                            std::string name) const override
+  {
     throw NotImplementedException("Not Implemented");
   };
-  smt::Term get_tester(const smt::Sort & s, std::string name) const {
+  smt::Term get_tester(const smt::Sort & s, std::string name) const override
+  {
     throw NotImplementedException("Not Implemented");
   };
-  smt::Term get_selector(const smt::Sort & s, std::string con, std::string name) const {
+  smt::Term get_selector(const smt::Sort & s,
+                         std::string con,
+                         std::string name) const override
+  {
     throw NotImplementedException("Not Implemented");
   };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,9 +2,10 @@
 #include <fstream>
 
 #include "opts.h"
+#include "lbv2isolver.h"
 #include "smt-switch/cvc4_factory.h"
 #include "smt-switch/msat_factory.h"
-#include "smtlibsolver.h"
+#include "smt-switch/smtlib_reader.h"
 
 using namespace lbv2i;
 using namespace std;
@@ -47,17 +48,19 @@ int main(int argc, char ** argv)
     assert(false);
   }
 
-  LBV2ISolver solver = LBV2ISolver(underlying_solver, opts.lazy);
+  smt::SmtSolver solver = std::make_shared<LBV2ISolver>(underlying_solver, opts.lazy);
+  SmtLibReader parser(solver);
 
-  if (num_files) {
-    ifstream ifile(filename);
-    if (!ifile) {
-      cout << "file does not exist" << endl;
-      return 1;
-    }
-    solver.run(filename);
+  if (num_files == 1) {
+    // ifstream ifile(filename);
+    // if (!ifile) {
+    //   cout << "file does not exist" << endl;
+    //   return 1;
+    // }
+    parser.parse(filename);
   } else {
-    solver.run_on_stdin();
+    cout << "usage: lazybv2int <filename>" << endl;
+    // can add a run on stdin option if needed
   }
 
   return 0;

--- a/src/postprocessor.h
+++ b/src/postprocessor.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include "smt-switch/identity_walker.h"
+#include <functional>
+#include <map>
+
+#include "identity_walker.h"
 #include "smt-switch/smt.h"
 #include "utils.h"
-#include <map>
-#include <functional>
 
 namespace lbv2i {
 enum RewriteRule
@@ -14,21 +15,20 @@ enum RewriteRule
   NUM_REWRITE_RULES
 };
 
-class Moderizer: public smt::IdentityWalker
+class Moderizer : public IdentityWalker
 {
  public:
   Moderizer(smt::SmtSolver & solver, utils* u);
   ~Moderizer();
 
-  typedef smt::IdentityWalker super;
+  typedef IdentityWalker super;
 
   smt::Term process(smt::Term t);
   bool is_fintmod(smt::Term t);
   smt::TermVec get_children(smt::Term t);
 
  protected:
-  smt::WalkerStepResult visit_term(smt::Term & term) override;
-
+  WalkerStepResult visit_term(smt::Term & term) override;
 
  private:
     utils* utils_;

--- a/src/preprocessor.h
+++ b/src/preprocessor.h
@@ -1,43 +1,43 @@
 #pragma once
 
-#include "smt-switch/identity_walker.h"
+#include "identity_walker.h"
 #include "smt-switch/smt.h"
 #include "utils.h"
 
 namespace lbv2i {
 
-class Binarizer : public smt::IdentityWalker
+class Binarizer : public IdentityWalker
 {
   // probably this class will inherit from SMT-Switch-Walker
  public:
   Binarizer(smt::SmtSolver & solver);
   ~Binarizer();
 
-  typedef smt::IdentityWalker super;
+  typedef IdentityWalker super;
   // it will also use the walker infrastructure
 
   smt::Term process(smt::Term t);
 
  protected:
-  smt::WalkerStepResult visit_term(smt::Term & term) override;
+  WalkerStepResult visit_term(smt::Term & term) override;
 
  private:
 };
 
-class OpEliminator : public smt::IdentityWalker
+class OpEliminator : public IdentityWalker
 {
   // probably this class will inherit from SMT-Switch-Walker
  public:
   OpEliminator(smt::SmtSolver & solver);
   ~OpEliminator();
 
-  typedef smt::IdentityWalker super;
+  typedef IdentityWalker super;
   // it will also use the walker infrastructure
 
   smt::Term process(smt::Term t);
 
  protected:
-  smt::WalkerStepResult visit_term(smt::Term & term) override;
+  WalkerStepResult visit_term(smt::Term & term) override;
 
  private:
 };

--- a/src/smtlibmsatparser.cpp
+++ b/src/smtlibmsatparser.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <vector>
 
-#include "msat/include/msat_term.h"
+#include "smt-switch/msat_term.h"
 #include "stdio.h"
 
 using namespace smt;


### PR DESCRIPTION
This PR updates the version of smt-switch and makes necessary changes so that it compiles and runs correctly. A few notable things:
* it now uses the SmtLibReader from smt-switch to parse files. However, it currently does not support `print-success`, or reading from `stdin`. I can add those things if needed
* the walkers in this codebase use the `cache_` directly often. Since the latest version of the `IdentityWalker` in smt-switch makes the `cache_` private, the easiest thing to do was just create another `IdentityWalker` based on the old `smt-switch` in this codebase.